### PR TITLE
fix: use patchedFS on module loader

### DIFF
--- a/src/runtime/patch/module_loader.js
+++ b/src/runtime/patch/module_loader.js
@@ -1,7 +1,7 @@
 // NOTE: this is re-implementation of some core methods of
 // https://github.com/nodejs/node/blob/v10.x/lib/internal/modules/cjs/loader.js
 
-import * as realFs from 'fs';
+import * as patchedFs from 'fs';
 import * as Module from 'module';
 import { isAbsolute, resolve, toNamespacedPath } from 'path';
 import { isWindows, isWindowsPath, stripBOM, unixifyPath } from '../../common';
@@ -110,12 +110,12 @@ export function patchModuleLoader(staticFsRuntime) {
   }
 
   Module._extensions['.js'] = (module, filename) => {
-    const readFileFn = stat(filename) === 0 ? sfs.readFileSync.bind(sfs) : realFs.readFileSync.bind(this);
+    const readFileFn = patchedFs.readFileSync.bind(this);
     module._compile(stripBOM(readFileFn(filename, 'utf8')), filename);
   };
 
   Module._extensions['.json'] = (module, filename) => {
-    const readFileFn = stat(filename) === 0 ? sfs.readFileSync.bind(sfs) : realFs.readFileSync.bind(this);
+    const readFileFn = patchedFs.readFileSync.bind(this);
 
     try {
       module.exports = JSON.parse(stripBOM(readFileFn(filename, 'utf8')));

--- a/src/runtime/runtime.js
+++ b/src/runtime/runtime.js
@@ -63,11 +63,11 @@ export function load(staticFsVolume) {
     global.__STATIC_FS_RUNTIME = {};
     global.__STATIC_FS_RUNTIME.staticfilesystem = new StaticFilesystem();
 
-    // patch module_loader (require fn)
-    const undo_loader = patchModuleLoader(global.__STATIC_FS_RUNTIME);
-
     // patch fs
     const undo_fs = patchFilesystem(global.__STATIC_FS_RUNTIME);
+
+    // patch module_loader (require fn)
+    const undo_loader = patchModuleLoader(global.__STATIC_FS_RUNTIME);
 
     // patch process
     const undo_process = patchProcess(global.__STATIC_FS_RUNTIME);
@@ -78,8 +78,8 @@ export function load(staticFsVolume) {
     global.__STATIC_FS_RUNTIME.undo = () => {
       undo_child_process();
       undo_process();
-      undo_fs();
       undo_loader();
+      undo_fs();
     };
   }
   global.__STATIC_FS_RUNTIME.staticfilesystem.load(staticFsVolume);

--- a/test/helpers/mock_project/test_cases/patch/module_loader_failure_after_undo.js
+++ b/test/helpers/mock_project/test_cases/patch/module_loader_failure_after_undo.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { patchModuleLoader } = require('static-fs/dist/runtime');
+const { patchFilesystem, patchModuleLoader } = require('static-fs/dist/runtime');
 const { sanitizePath } = require('../../utils');
 
 const mockFs = {
@@ -45,7 +45,9 @@ const mockStaticFsRuntime = {
   staticfilesystem: mockFs,
 };
 
+const undo_filesystem_patch = patchFilesystem(mockStaticFsRuntime);
 const undo_module_loader_patch = patchModuleLoader(mockStaticFsRuntime);
 require('./static_fs_mock/patched/path/file');
 undo_module_loader_patch();
 require('./static_fs_mock/patched/path/file');
+undo_filesystem_patch();

--- a/test/helpers/mock_project/test_cases/patch/module_loader_success.js
+++ b/test/helpers/mock_project/test_cases/patch/module_loader_success.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { patchModuleLoader } = require('static-fs/dist/runtime');
+const { patchFilesystem, patchModuleLoader } = require('static-fs/dist/runtime');
 const { sanitizePath } = require('../../utils');
 
 const mockFs = {
@@ -45,7 +45,9 @@ const mockStaticFsRuntime = {
   staticfilesystem: mockFs,
 };
 
+const undo_filesystem_patch = patchFilesystem(mockStaticFsRuntime);
 const undo_module_loader_patch = patchModuleLoader(mockStaticFsRuntime);
 const staticFsPatchedPathFileExport = require('./static_fs_mock/patched/path/file');
 console.log(staticFsPatchedPathFileExport);
 undo_module_loader_patch();
+undo_filesystem_patch();


### PR DESCRIPTION
That is a small improvement in order to use the patchedFS only inside the module loader override fns.