### PR TITLE
fix: use resolve on node path to string fn

### DIFF
--- a/src/common/path.js
+++ b/src/common/path.js
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { isWindows } from './constants';
 
 function getPathFromURLPosix(url) {
@@ -50,7 +51,7 @@ export function nodePathToString(path) {
     throw er;
   }
 
-  return pathString;
+  return resolve(pathString);
 }
 
 export function unixifyPath(filePath) {

--- a/test/fixtures/node_modules/mock_simple_module_relative/read_content_file.js
+++ b/test/fixtures/node_modules/mock_simple_module_relative/read_content_file.js
@@ -9,10 +9,7 @@ const fileContentBuffer = fs.readFileSync(
 );
 
 const fileContentEncoded = fs.readFileSync(
-  path.resolve(
-    __dirname,
-    './content.txt'
-  ),
+  '../node_modules/mock_simple_module_relative/content.txt',
   'utf8'
 );
 


### PR DESCRIPTION
It insures a path coming into this function is always resolved. The test was updated to match that.